### PR TITLE
[#9] Support the wd (working directory) argument

### DIFF
--- a/pkg/proc/gdbserial/undo.go
+++ b/pkg/proc/gdbserial/undo.go
@@ -54,6 +54,10 @@ func UndoRecord(cmd []string, wd string, quiet bool) (recording string, err erro
 	args = append(args, cmd...)
 	lrcmd := exec.Command("live-record", args...)
 
+	if wd != "" {
+		lrcmd.Dir = wd
+	}
+
 	if !quiet {
 		lrcmd.Env = os.Environ()
 		// Setting UNDO_debug_level alone is not enough


### PR DESCRIPTION
Fixes #9.

```
$ go run scripts/make.go test -v -s proc -r TestWorkDir -b undo
go test -count 1 -p 1 -v "-ldflags=-X main.Build=e5dbc149436cd4d4694f141d87fa6ea936eb695e" github.com/undoio/delve/pkg/proc -run=TestWorkDir -backend=undo
=== RUN   TestWorkDir
--- PASS: TestWorkDir (1.86s)
    support.go:246: enabling recording for github.com/undoio/delve/pkg/proc_test.TestWorkDir
    proc_test.go:81: recording
    proc_test.go:83: replaying
PASS
ok  	github.com/undoio/delve/pkg/proc	1.862s
```