### PR TITLE
[#12] Avoid failures from TestAttachDetach and TestAttachStripped.

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2759,7 +2759,7 @@ func TestAttachDetach(t *testing.T) {
 			return
 		}
 	}
-	if testBackend == "rr" {
+	if testBackend == "rr" || testBackend == "undo" {
 		return
 	}
 	var buildFlags protest.BuildFlags
@@ -3057,7 +3057,7 @@ func TestAttachStripped(t *testing.T) {
 			return
 		}
 	}
-	if testBackend == "rr" {
+	if testBackend == "rr" || testBackend == "undo" {
 		return
 	}
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
Fixes #12.
```
$ go run scripts/make.go test -v -s proc -r TestAttachDetach -b undo
=== RUN   TestAttachDetach
--- PASS: TestAttachDetach (0.00s)
PASS
ok  	github.com/undoio/delve/pkg/proc	0.002s
$ go run scripts/make.go test -v -s proc -r TestAttachStripped -b undo
=== RUN   TestAttachStripped
--- PASS: TestAttachStripped (0.00s)
PASS
ok  	github.com/undoio/delve/pkg/proc	0.003s
```