### PR TITLE
[#8] Avoid failure from TestIssue871

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2970,7 +2970,7 @@ func TestIssue871(t *testing.T) {
 
 		var scope *proc.EvalScope
 		var err error
-		if testBackend == "rr" {
+		if testBackend == "rr" || testBackend == "undo" {
 			var frame proc.Stackframe
 			frame, err = findFirstNonRuntimeFrame(p)
 			if err == nil {


### PR DESCRIPTION
Fixes #8.
```
$ go run scripts/make.go test -v -s proc -r TestIssue871 -b undo
=== RUN   TestIssue871
--- PASS: TestIssue871 (1.76s)
    support.go:246: enabling recording for github.com/undoio/delve/pkg/proc_test.TestIssue871
    proc_test.go:81: recording
    proc_test.go:83: replaying
    proc_test.go:2990: local &{824633812160 false a [3]int [3]int array 0xc0004b0e40 0xc0000bac60 <nil> 0 3 -1 1 824633812160 8 0xc0005b3240 0 0 [{824633812160 false  int int int 0xc0004b0e40 0xc0000bac60 1 0 0 0 0 0 0 <nil> 0 0 [] true <nil>  0} {824633812168 false  int int int 0xc0004b0e40 0xc0000bac60 2 0 0 0 0 0 0 <nil> 0 0 [] true <nil>  0} {824633812176 false  int int int 0xc0004b0e40 0xc0000bac60 3 0 0 0 0 0 0 <nil> 0 0 [] true <nil>  0}] true <nil> [block] DW_OP_fbreg -0x60  (escaped) 9}
    proc_test.go:2990: local &{824634240736 false b *[3]int *[3]int ptr 0xc0004b0d40 0xc0000bac60 <nil> 0 1 0 0 0 0 <nil> 0 0 [{824633812160 false  [3]int [3]int array 0xc0004b0e80 0xc0000bac60 <nil> 0 3 -1 0 824633812160 8 0xc0005b3240 0 0 [{824633812160 false  int int int 0xc0004b0e80 0xc0000bac60 1 0 0 0 0 0 0 <nil> 0 0 [] true <nil>  0} {824633812168 false  int int int 0xc0004b0e80 0xc0000bac60 2 0 0 0 0 0 0 <nil> 0 0 [] true <nil>  0} {824633812176 false  int int int 0xc0004b0e80 0xc0000bac60 3 0 0 0 0 0 0 <nil> 0 0 [] true <nil>  0}] true <nil>  0}] true <nil> [block] DW_OP_fbreg -0x80  10}
PASS
ok  	github.com/undoio/delve/pkg/proc	1.764s
```