### PR TITLE
[#24] Update udbserver filenames (changed in UDB 6.2.1).

### DIFF
--- a/pkg/proc/gdbserial/undo.go
+++ b/pkg/proc/gdbserial/undo.go
@@ -12,11 +12,11 @@ import (
 func serverFile() (string, error) {
 	switch runtime.GOARCH {
 	case "amd64":
-		return "undodb-server_x64", nil
+		return "udbserver_x64", nil
 	case "arm64":
-		return "undodb-server_arm64", nil
+		return "udbserver_arm64", nil
 	case "386":
-		return "undodb-server_x32", nil
+		return "udbserver_x32", nil
 	default:
 		return "", &ErrBackendUnavailable{}
 	}


### PR DESCRIPTION
The undodb-server aliases are likely to be removed in UDB 7 and we the Delve fork must not break when that happens.

Fixes #24 (Undo backend uses deprecated udbserver aliases)