### PR TITLE
Fix bugs and UX issues in Undo's Delve fork

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1127,11 +1127,11 @@ func (p *gdbProcess) When() (string, error) {
 	}
 	result := ""
 	if p.conn.isUndoServer {
-		extent, err := p.conn.undoCmd("get_time")
+		when, err := undoWhen(&p.conn)
 		if err != nil {
 			return "", err
 		}
-		result = extent
+		result = when
 	} else {
 		event, err := p.conn.qRRCmd("when")
 		if err != nil {

--- a/pkg/proc/gdbserial/undo.go
+++ b/pkg/proc/gdbserial/undo.go
@@ -250,3 +250,12 @@ func undoGetExitCode(conn *gdbConn) (int, error) {
 
 	return exit_code, nil
 }
+
+// Fetch a representation of the current time as a string.
+func undoWhen(conn *gdbConn) (string, error) {
+	extent, err := conn.undoCmd("get_time")
+	if err != nil {
+		return "", err
+	}
+	return extent, nil
+}

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -107,6 +107,9 @@ func (grp *TargetGroup) Continue() error {
 			// might very well not work.
 			_ = grp.setCurrentThreads(traptgt, trapthread)
 			if pe, ok := contOnceErr.(ErrProcessExited); ok {
+				// With a replay backend we may still debug after an apparent
+				// process exit so we still need to clean up our stepping state.
+				traptgt.ClearSteppingBreakpoints()
 				traptgt.exitStatus = pe.Status
 			}
 			return contOnceErr


### PR DESCRIPTION
This PR fixes a number of issues in Undo's Delve fork:

 * Debugging cannot continue after playing forward to process exit.
 * Undo time is not displayed clearly to the user.
 * Debugging cannot continue after stepping forward to process exit (using a command that sets stepping breakpoints, e.g. `step` or `next`)