### PR TITLE
Time-handling improvements

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1144,7 +1144,19 @@ func (p *gdbProcess) restartWorker(cctx *proc.ContinueOnceContext, pos string) (
 
 	p.ctrlC = false
 
-	err := p.conn.restart(pos)
+	var err error
+	if p.conn.isUndoServer {
+		switch pos {
+		case "start":
+			err = p.conn.restart("")
+		case "end":
+			_, err = p.conn.undoCmd("goto_record_mode")
+		default:
+			err = p.conn.restart(pos)
+		}
+	} else {
+		err = p.conn.restart(pos)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1250,6 +1250,13 @@ func (p *gdbProcess) Checkpoints() ([]proc.Checkpoint, error) {
 	if p.conn.isUndoServer {
 		r := make([]proc.Checkpoint, 0, len(p.localCheckpoints))
 		for _, cp := range p.localCheckpoints {
+			// Convert the internal representation of time (which is based on the serial
+			// protocol level representation) to a human-readable version for display.
+			bbcount, pc, err := undoParseServerTime(cp.When)
+			if err != nil {
+				return nil, err
+			}
+			cp.When = undoTimeString(bbcount, pc)
 			r = append(r, cp)
 		}
 		return r, nil

--- a/pkg/proc/gdbserial/undo.go
+++ b/pkg/proc/gdbserial/undo.go
@@ -296,7 +296,20 @@ func undoGetExitCode(conn *gdbConn) (int, error) {
 
 // Print a bbcount and PC pair in standard Undo time notiation.
 func undoTimeString(bbcount uint64, pc uint64) string {
-	return fmt.Sprintf("%d:0x%x", bbcount, pc)
+	var bbcount_groups []string
+
+	// Chop 3 digits at a time from the low-order end of the bbcount string.
+	var bbcount_rem uint64
+	for bbcount_rem = bbcount; bbcount_rem > 1000; bbcount_rem = bbcount_rem / 1000 {
+		// Format the group with leading zeros.
+		group := fmt.Sprintf("%03d", bbcount_rem%1000)
+		bbcount_groups = append([]string{group}, bbcount_groups...)
+	}
+	// Finally, add the highest-order group, which has no leading zeros.
+	bbcount_groups = append([]string{fmt.Sprintf("%d", bbcount_rem)}, bbcount_groups...)
+
+	// Return the comma-separated whole.
+	return fmt.Sprintf("%s:0x%x", strings.Join(bbcount_groups, ","), pc)
 }
 
 // Parse the udbserver serial-level representation of a time into bbcount and PC.


### PR DESCRIPTION
Improve the handling of times and time navigation in Delve.

 * Print bbcounts with comma thousands separators, as in UDB.
 * Show human-readable times in the output of the `checkpoints` command.
 * Add magic "start" and "end" checkpoints for quickly jumping to extremes of history.
 * Add arg parsing so `restart <bbcount>` and `restart <bbcount:pc>` can be used.