### PR TITLE
Undo v1.20.2-3 + session checkpoints

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1278,7 +1278,7 @@ func (p *gdbProcess) ClearCheckpoint(id int) error {
 
 	// Handle locally managed checkpoints first
 	if p.conn.isUndoServer {
-		p.undoSession.deleteCheckpoint(id)
+		p.undoSession.deleteCheckpoint(p, id)
 		// We don't care if it didn't exist
 		return nil
 	}

--- a/pkg/proc/gdbserial/undo.go
+++ b/pkg/proc/gdbserial/undo.go
@@ -2,13 +2,16 @@ package gdbserial
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -18,6 +21,9 @@ import (
 
 // State relating to an Undo "session" - used to correctly interpret and handle time-travel
 // operations on a gdbProcess when running with the Undo backend.
+//
+// The current checkpoints are persisted to disk in an "Undo session file" via the save() method.
+// They are restored via the load() method.
 //
 // See also: isUndoServer on the gdbConn structure - when that is set, the undoSession member on the
 // gdbProcess structure should point to an instance of this structure.
@@ -34,8 +40,44 @@ func newUndoSession() *undoSession {
 	}
 }
 
+// Validate a checkpoint note to ensure easy interopability with UDB bookmarks.
+// Returns nil (no error) if a checkpoint is validated successfully.
+func validateCheckpointNote(where string) error {
+	if where == "" {
+		panic("checkpoint note expectedly empty.")
+	}
+
+	// Perform matching checking to UDB's bookmark creation code, to ensure Delve notes
+	// translate properly into UDB bookmarks when we save the session.
+	//
+	// (compare Bookmarks._verify_name() in the UDB Python code)
+	firstChar := where[0:1]
+	if firstChar == " " {
+		return errors.New("checkpoint note must not start with a space.")
+	} else if _, err := strconv.Atoi(firstChar); err == nil {
+		return errors.New("checkpoint note must not start with a digit.")
+	} else if firstChar == "," || firstChar == "-" || firstChar == "$" {
+		return fmt.Errorf("checkpoint note must not start with character: %c", where[0])
+	} else {
+		firstWord := strings.Split(where, " ")[0]
+		reserved := []string{"annotation", "bookmark", "end", "event", "inferior", "pc",
+			"redo", "start", "time", "undo", "wallclock"}
+		for _, reservedWord := range reserved {
+			if firstWord == reservedWord {
+				return fmt.Errorf("checkpoint note must not start with reserved word: %s", reservedWord)
+			}
+		}
+	}
+
+	return nil
+}
+
 // Create a Delve checkpoint structure at the current time, with the supplied note.
 func (uc *undoSession) createCheckpoint(p *gdbProcess, where string) (int, error) {
+	err := validateCheckpointNote(where)
+	if err != nil {
+		return -1, err
+	}
 	cpid := uc.checkpointLastId
 	uc.checkpointLastId++
 	when, err := p.conn.undoCmd("get_time")
@@ -43,6 +85,7 @@ func (uc *undoSession) createCheckpoint(p *gdbProcess, where string) (int, error
 		return -1, err
 	}
 	uc.checkpoints[cpid] = proc.Checkpoint{ID: cpid, When: when, Where: where}
+	uc.save(p)
 	return cpid, nil
 }
 
@@ -63,8 +106,9 @@ func (uc *undoSession) lookupCheckpoint(pos string) (proc.Checkpoint, error) {
 }
 
 // Delete a Delve checkpoint structure from our tracking.
-func (uc *undoSession) deleteCheckpoint(id int) {
+func (uc *undoSession) deleteCheckpoint(p *gdbProcess, id int) {
 	delete(uc.checkpoints, id)
+	uc.save(p)
 }
 
 // Fetch all Delve checkpoint structures and return an array for user display (with the When field
@@ -82,6 +126,148 @@ func (uc *undoSession) getCheckpoints() ([]proc.Checkpoint, error) {
 		r = append(r, cp)
 	}
 	return r, nil
+}
+
+// Represents a single serialised bookmark in our session file format.
+type bookmarkTime struct {
+	Bbcount uint64 `json:"bbcount"`
+	Pc      uint64 `json:"pc"`
+}
+
+// Represents the overall structure of our session file format.
+type session struct {
+	Bookmarks map[string]bookmarkTime `json:"bookmarks"`
+}
+
+// Get the path to the UDB session file for the current recording.
+func getSessionPath(p *gdbProcess) (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	recording_ids, err := p.conn.undoCmd("get_recording_ids")
+	if err != nil {
+		return "", err
+	}
+	uuids := strings.Split(recording_ids, ";")
+	if len(uuids) != 3 || uuids[1] == "" {
+		panic("unexpected response from get_recording_ids")
+	}
+
+	// This directory stores sessions.
+	xdg_data_dir, present := os.LookupEnv("XDG_DATA_HOME")
+	if !present {
+		xdg_data_dir = filepath.Join(user.HomeDir, ".local", "share")
+	}
+	undo_sessions_dir := filepath.Join(xdg_data_dir, "undo", "sessions")
+
+	err = os.MkdirAll(undo_sessions_dir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	file := filepath.Join(undo_sessions_dir, string(uuids[1])+".json")
+
+	return file, nil
+}
+
+// Load the UDB session file (if it exists) for the current recording.
+func (uc *undoSession) load(p *gdbProcess) error {
+	path, err := getSessionPath(p)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+
+	var s session
+	err = decoder.Decode(&s)
+	if err != nil {
+		return err
+	}
+
+	// Clear out the session data.
+	*uc = *newUndoSession()
+
+	// Translate the loaded Undo bookmarks into Delve checkpoints.
+	for name, position := range s.Bookmarks {
+		cpid := uc.checkpointLastId
+		uc.checkpointLastId++
+		uc.checkpoints[cpid] = proc.Checkpoint{
+			ID:    cpid,
+			When:  fmt.Sprintf("%x,%x", position.Bbcount, position.Pc),
+			Where: name,
+		}
+	}
+
+	return err
+}
+
+// Save the session file for the current recording.
+func (uc *undoSession) save(p *gdbProcess) error {
+	// Translate Delve checkpoints into Undo bookmarks.
+	var s session
+	s.Bookmarks = make(map[string]bookmarkTime)
+
+	// Local copy of the checkopints.
+	var checkpoints []proc.Checkpoint
+	for _, cp := range uc.checkpoints {
+		checkpoints = append(checkpoints, cp)
+	}
+	// Sort the checkpoints by descending note length - this is to avoid adding a suffix to a
+	// entries that we've already added a suffix to. e.g. if we've previously saved this session
+	// with a duplicated checkpoint note called "test" then we'll have extended one to
+	// "test-0". If the user adds "test" again, we want to rename that to "test-1" rather than
+	// creating a "test-0-0".
+	sort.Slice(checkpoints, func(i, j int) bool {
+		// This is a "Less" function that sorts in descending order of string length.
+		return len(checkpoints[i].Where) > len(checkpoints[j].Where)
+	})
+
+	// Iterate through sorted checkpoints to eliminate duplicates.
+	for _, cp := range checkpoints {
+		// Ensure that notes are made unique before saving - UDB expects bookmark names to
+		// be unique.
+		base_name := cp.Where
+		name := base_name
+		for i := 0; s.Bookmarks[name] != (bookmarkTime{}); i++ {
+			name = fmt.Sprintf("%s-%d", base_name, i)
+		}
+
+		var time bookmarkTime
+		_, err := fmt.Sscanf(cp.When, "%x,%x", &time.Bbcount, &time.Pc)
+		if err != nil {
+			return err
+		}
+		s.Bookmarks[name] = time
+	}
+
+	path, err := getSessionPath(p)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "    ")
+	err = encoder.Encode(&s)
+	if err != nil {
+		return err
+	}
+
+	return err
 }
 
 // Transform a user-specified time into a canonical form. The returned string has been validated
@@ -290,6 +476,9 @@ func UndoReplay(recording string, path string, quiet bool, debugInfoDirs []strin
 
 	// Create storage for Undo checkpoints, which (unlike rr) aren't stored in the server.
 	p.undoSession = newUndoSession()
+
+	// Load the session details if possible (discarding errors, which are non-fatal).
+	_ = p.undoSession.load(p)
 
 	return tgt, nil
 }

--- a/pkg/proc/gdbserial/undo.go
+++ b/pkg/proc/gdbserial/undo.go
@@ -292,7 +292,7 @@ func (uc *undoSession) resolveUserTime(p *gdbProcess, pos string) (string, error
 			return "", err
 		}
 		pos = checkpoint.When
-	} else {
+	} else if pos != "" {
 		// Validate a potential bbcount or precise time.
 		pos = strings.ReplaceAll(pos, ",", "")
 		var bbcount, pc uint64


### PR DESCRIPTION
Extend previous work on the `restart` command and checkpoint facilities to support save/load of sessions in a compatible format to UDB.

This PR introduces the concept of an `undoSession` object, which stores checkpoints and is provided as a context for resolving user-specified times.  This enables it to do appropriate look-up for checkpoints when required and gives us a home for session-management (such as saving and loading the JSON file).