### PR TITLE
undo-v1.21.0-1 - Support for v1 (UDB v7.0) session files & Use files from a recording to load debug symbols

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -656,6 +656,16 @@ func (p *gdbProcess) EntryPoint() (uint64, error) {
 // stubs will report both the PID and executable path.
 func (p *gdbProcess) initialize(path, cmdline string, debugInfoDirs []string, stopReason proc.StopReason) (*proc.TargetGroup, error) {
 	var err error
+
+	if p.conn.undoSession != nil {
+		// Always use the path from the recording file, so that we have consistent debug
+		// symbols. Allowing the user to specify other paths is out of scope for now.
+		path, err = undoGetExePath(&p.conn)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if path == "" {
 		// If we are attaching to a running process and the user didn't specify
 		// the executable file manually we must ask the stub for it.

--- a/pkg/proc/gdbserial/undo.go
+++ b/pkg/proc/gdbserial/undo.go
@@ -270,7 +270,7 @@ func (uc *undoSession) save(conn *gdbConn) error {
 		return err
 	}
 
-	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -179,7 +179,7 @@ func New(config *Config, processArgs []string) (*Debugger, error) {
 			d.target, err = gdbserial.Replay(d.config.CoreFile, false, false, d.config.DebugInfoDirectories, d.config.RrOnProcessPid, "")
 		case "undo":
 			d.log.Infof("opening recording %s", d.config.CoreFile)
-			d.target, err = gdbserial.UndoReplay(d.config.CoreFile, "", false, d.config.DebugInfoDirectories, "")
+			d.target, err = gdbserial.UndoReplay(d.config.CoreFile, false, d.config.DebugInfoDirectories, "")
 		default:
 			d.log.Infof("opening core file %s (executable %s)", d.config.CoreFile, d.processArgs[0])
 			d.target, err = core.OpenCore(d.config.CoreFile, d.processArgs[0], d.config.DebugInfoDirectories)


### PR DESCRIPTION
This PR contains:

* A fix to open session data files using `O_TRUNC` to avoid accidentally creating invalid session files. 
* Support for loading v1 of our session file format (as generated by UDB v7.0), including the ability to pass through UDB-generated fields non-destructively.  Delve continues to interest itself only in the "bookmarks" element (which corresponds to its internal notion of Checkpoints).
 * A fix to use the original executable, as stored in the recording, to load symbols instead of looking up its original path on disk.