### PR TITLE
Handle another new session field from UDB

### DIFF
--- a/pkg/proc/gdbserial/undo.go
+++ b/pkg/proc/gdbserial/undo.go
@@ -182,6 +182,7 @@ type session struct {
 	Sysroot               interface{}             `json:"sysroot,omitempty"`
 	ConvenienceVariables  interface{}             `json:"convenience_variables,omitempty"`
 	TelemetryId           interface{}             `json:"telemetry_id,omitempty"`
+	Language              interface{}             `json:"language,omitempty"`
 }
 
 // Get the path to the UDB session file for the current recording.


### PR DESCRIPTION
Development versions of Undo add support for saving an explicitly set language to the session information.

Removing the `DisallowUnknownFields` is probably sensible in the future.